### PR TITLE
Fix user search balance display and admin panel loading

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -47,4 +47,14 @@ const App = () => (
   </QueryClientProvider>
 );
 
-createRoot(document.getElementById("root")!).render(<App />);
+// Prevent multiple createRoot calls during HMR or double-bundling
+const rootEl = document.getElementById("root");
+if (rootEl) {
+  // @ts-ignore
+  if (!(window as any).__fusion_root) {
+    // @ts-ignore
+    (window as any).__fusion_root = createRoot(rootEl);
+  }
+  // @ts-ignore
+  (window as any).__fusion_root.render(<App />);
+}

--- a/client/components/layout/Header.tsx
+++ b/client/components/layout/Header.tsx
@@ -2,6 +2,7 @@ import { ThemeToggle } from "@/components/ThemeToggle";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { useAuth } from "@/context/AuthContext";
+import { computeRemaining } from "@/lib/user";
 import { LogIn } from "lucide-react";
 import { Link, NavLink, useLocation, useNavigate } from "react-router-dom";
 import {
@@ -74,9 +75,7 @@ export function Header() {
                         Balance
                       </span>
                       <span className="inline-flex items-center gap-1 rounded-full bg-brand-500/10 text-brand-700 dark:text-brand-300 px-2 py-0.5 text-xs font-semibold">
-                        {typeof profile?.totalSearchesRemaining === "number"
-                          ? profile.totalSearchesRemaining
-                          : 0}
+                        {computeRemaining(profile)}
                       </span>
                     </span>
                   </button>

--- a/client/context/AuthContext.tsx
+++ b/client/context/AuthContext.tsx
@@ -45,8 +45,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           unsubProfile = undefined;
         }
         if (u) {
-          const ensured = await ensureUserDoc(u.uid, u.email, u.displayName);
-          setProfile(ensured);
+          try {
+            const ensured = await ensureUserDoc(u.uid, u.email, u.displayName);
+            setProfile(ensured);
+          } catch (e) {
+            console.warn("ensureUserDoc failed: ", e);
+          }
           try {
             const db = getDbInstance();
             const ref = doc(db, "users", u.uid);

--- a/client/lib/user.ts
+++ b/client/lib/user.ts
@@ -86,12 +86,15 @@ async function normalizeExistingProfile(uid: string, existing: UserProfile) {
   const explicitRemaining = Number(existing.totalSearchesRemaining);
   const needsFreeFix = free !== existing.freeSearches;
   const needsRemainingFix =
-    !Number.isFinite(explicitRemaining) || explicitRemaining !== derivedRemaining;
+    !Number.isFinite(explicitRemaining) ||
+    explicitRemaining !== derivedRemaining;
 
   if (needsFreeFix || needsRemainingFix) {
     await updateDoc(ref, {
       ...(needsFreeFix ? { freeSearches: free } : {}),
-      ...(needsRemainingFix ? { totalSearchesRemaining: derivedRemaining } : {}),
+      ...(needsRemainingFix
+        ? { totalSearchesRemaining: derivedRemaining }
+        : {}),
       updatedAt: serverTimestamp(),
     });
     return {

--- a/client/pages/Databases.tsx
+++ b/client/pages/Databases.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useAuth } from "@/context/AuthContext";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { consumeSearchCredit } from "@/lib/user";
+import { consumeSearchCredit, computeRemaining } from "@/lib/user";
 import { toast } from "sonner";
 
 export default function Databases() {
@@ -20,7 +20,7 @@ export default function Databases() {
     setQuery(initialQ);
   }, [initialQ]);
 
-  const remaining = profile?.totalSearchesRemaining ?? 0;
+  const remaining = computeRemaining(profile);
 
   async function onSearch() {
     if (!query.trim()) return;


### PR DESCRIPTION
## Purpose

Fix critical user experience issues where new users see 0 searches instead of the expected 2 free searches, and resolve admin panel loading problems. The user reported that while Firestore shows 3 free searches (should be 2), the website displays 0, and admin users cannot access the admin panel due to infinite loading.

## Code changes

- **Added `computeRemaining()` utility function** to consistently calculate remaining searches from free + purchased - used searches, with fallback logic for invalid data
- **Updated Header and Databases components** to use the new computation function instead of directly reading `totalSearchesRemaining`
- **Added profile normalization logic** in `ensureUserDoc()` to automatically fix existing user profiles by clamping free searches to max 2 and syncing the remaining count
- **Added error handling** in AuthContext to prevent crashes when user document creation fails
- **Implemented data migration** to fix inconsistent search balance data for existing users

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/adb1c8b857c5418abf8ba84af067783d/aura-nest)

👀 [Preview Link](https://adb1c8b857c5418abf8ba84af067783d-aura-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>adb1c8b857c5418abf8ba84af067783d</projectId>-->
<!--<branchName>aura-nest</branchName>-->